### PR TITLE
Show appropriate error message if composer autoload is missing

### DIFF
--- a/mobile-bankid-integration.php
+++ b/mobile-bankid-integration.php
@@ -28,6 +28,11 @@ if ( ! class_exists( 'mobile_bankid_integration' ) ) {
 		 * Class constructor.
 		 */
 		public function __construct() {
+			// Check if composer autoload exists.
+			if ( ! file_exists( MOBILE_BANKID_INTEGRATION_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
+				wp_die( wp_kses_post( __( '<strong>Mobile BankID Integration</strong> requires its dependencies to be installed. These are included in all releases, but if you are using the development version, you need to run <code>composer install</code> in the plugin directory.', 'mobile-bankid-integration' ) ) );
+			}
+
 			// Composer autoload.
 			require_once MOBILE_BANKID_INTEGRATION_PLUGIN_DIR . 'vendor/autoload.php';
 


### PR DESCRIPTION
As of now the plugin writes the following error message if we try to install it without composer autoload available:

> [23-Dec-2023 17:04:07 UTC] PHP Warning: require_once([local_path]\wp-content\plugins\WP-Mobile-BankID-Integration/vendor/autoload.php): Failed to open stream: No such file or directory in [local_path]\wp-content\plugins\WP-Mobile-BankID-Integration\mobile-bankid-integration.php on line 26
> [23-Dec-2023 17:04:07 UTC] PHP Fatal error: Uncaught Error: Failed opening required '[local_path]\wp-content\plugins\WP-Mobile-BankID-Integration/vendor/autoload.php' (include_path='.:/usr/share/php:/www/wp-content/pear') in [local_path]\wp-content\plugins\WP-Mobile-BankID-Integration\mobile-bankid-integration.php:26
> Stack trace:
> #0 [local_path]\wp-content\plugins\WP-Mobile-BankID-Integration\mobile-bankid-integration.php(54): mobile_bankid_integration->__construct()
> #1 [local_path]\wp-admin\includes\plugin.php(2318): include_once('[local_path]...')
> #2 [local_path]\wp-admin\includes\plugin.php(663): plugin_sandbox_scrape('WP-Mobile-BankI...')
> #3 [local_path]\wp-admin\plugins.php(58): activate_plugin('WP-Mobile-BankI...', 'http://[local_website]', false)
> #4 {main}
> thrown in [local_path]\wp-content\plugins\WP-Mobile-BankID-Integration\mobile-bankid-integration.php on line 26

This Pull request implements checks whether composer autoload is available and shows this error message if not:

> **Mobile BankID Integration** requires its dependencies to be installed. These are included in all releases, but if you are using the development version, you need to run `composer install` in the plugin directory.

This improves the user experience and gives real instructions on how to fix the problem.