### PR TITLE
Resolved a bug causing allowed HTML tags to be stripped in terms

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -215,23 +215,10 @@ class Admin {
 			<div class="form-group">
 				<label for="mobile-bankid-integration-terms"><?php esc_html_e( 'Terms to show with login (Supports HTML)', 'mobile-bankid-integration' ); ?></label>
 				<textarea name="mobile-bankid-integration-terms" id="mobile-bankid-integration-terms" rows="5"><?php // phpcs:ignore -- PHP tag needed to prevent whitespace in textarea.
-					echo wp_kses(
-						get_option( 'mobile_bankid_integration_terms', __( 'By logging in using Mobile BankID you agree to our Terms of Service and Privacy Policy.', 'mobile-bankid-integration' ) ),
-						array(
-							'a'      => array(
-								'href'   => array(),
-								'title'  => array(),
-								'target' => array(),
-							),
-							'br'     => array(),
-							'em'     => array(),
-							'strong' => array(),
-							'i'      => array(),
-						)
-					);
+					echo wp_kses( get_option( 'mobile_bankid_integration_terms', __( 'By logging in using Mobile BankID you agree to our Terms of Service and Privacy Policy.', 'mobile-bankid-integration' ) ), 'mobile_bankid_integration_terms' );
 					// phpcs:ignore -- PHP tag needed to prevent whitespace in textarea.
 					?></textarea>
-				<p class="description"><?php esc_html_e( 'Following HTML elements are supported: a, br, em, strong and i. All others will be escaped.', 'mobile-bankid-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Following HTML elements are supported: a, br, em, strong and i. All others HTML tags will be stripped.', 'mobile-bankid-integration' ); ?></p>
 			</div>
 		</form>
 		<button class="button button-primary" onclick="settingsSubmit()" id="mobile-bankid-integration-save"><?php esc_html_e( 'Save changes', 'mobile-bankid-integration' ); ?></button>

--- a/includes/settings/class-api.php
+++ b/includes/settings/class-api.php
@@ -161,7 +161,7 @@ class API {
 		// Get params.
 		$wplogin      = isset( $_POST['wplogin'] ) ? sanitize_text_field( wp_unslash( $_POST['wplogin'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification
 		$registration = isset( $_POST['registration'] ) ? sanitize_text_field( wp_unslash( $_POST['registration'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification
-		$terms        = isset( $_POST['terms'] ) ? sanitize_text_field( wp_unslash( $_POST['terms'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+		$terms        = isset( $_POST['terms'] ) ? wp_kses( wp_unslash( $_POST['terms'] ), 'mobile_bankid_integration_terms' ) : null; // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( ! in_array( $wplogin, array( 'as_alternative', 'hide' ), true ) ) {
 			return new \WP_Error( 'invalid_wplogin', esc_html__( 'Invalid value for wplogin.', 'mobile-bankid-integration' ), array( 'status' => 400 ) );

--- a/includes/wp-login/class-login.php
+++ b/includes/wp-login/class-login.php
@@ -25,6 +25,7 @@ class Login {
 				40
 			);
 		}
+		add_filter( 'wp_kses_allowed_html', array( $this, 'terms_allowed_html' ), 10, 2 );
 	}
 
 	/**
@@ -138,21 +139,38 @@ class Login {
 			<?php
 			echo wp_kses(
 				get_option( 'mobile_bankid_integration_terms', esc_html__( 'By logging in using Mobile BankID you agree to our Terms of Service and Privacy Policy.', 'mobile-bankid-integration' ) ),
-				array(
-					'a'      => array(
-						'href'   => array(),
-						'title'  => array(),
-						'target' => array(),
-					),
-					'br'     => array(),
-					'em'     => array(),
-					'strong' => array(),
-					'i'      => array(),
-				)
+				'mobile_bankid_integration_terms'
 			);
 			?>
 		</p>
 		<?php
+	}
+
+	/**
+	 * Add allowed HTML for terms.
+	 *
+	 * @param array  $allowedtags Allowed tags.
+	 * @param string $context     Context.
+	 * @return array
+	 *
+	 * @since 1.4.1 Added the context 'mobile_bankid_integration_terms'.
+	 */
+	public function terms_allowed_html( $allowedtags, $context ) {
+		if ( 'mobile_bankid_integration_terms' !== $context ) {
+			return $allowedtags;
+		}
+
+		return array(
+			'a'      => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'em'     => array(),
+			'strong' => array(),
+			'i'      => array(),
+		);
 	}
 
 	/**


### PR DESCRIPTION
This pull request includes a bug fix and several changes to improve the handling of HTML elements in the terms and conditions text for the Mobile BankID integration. The key changes involve updating the sanitization and escaping of HTML elements to ensure better security and consistency across different parts of the codebase.

Improvements to HTML sanitization and escaping:

* [`includes/admin/class-admin.php`](diffhunk://#diff-ea9dcc68dc045410769870752b2d13527050c8197c29df5cc2a6097c1edf4cc5L218-R221): Updated the `page_settings` method to use a custom context `mobile_bankid_integration_terms` for `wp_kses` to sanitize the terms text. Modified the description to clarify that unsupported HTML tags will be stripped.
* [`includes/settings/class-api.php`](diffhunk://#diff-3e971a122c8fe69f45388f4ed165b4ccab45ad57a7d1959245860a845de85f98L164-R164): Changed the `settings` method to use `wp_kses` with the custom context `mobile_bankid_integration_terms` for sanitizing the terms text received from POST requests.
* [`includes/wp-login/class-login.php`](diffhunk://#diff-e3a6790de2ebcce71d98722ebc36dce43c711d945a0e79a44e9f278f5d0f19e9R28): Added a new filter `terms_allowed_html` to specify the allowed HTML tags for the custom context `mobile_bankid_integration_terms`. Updated the `terms` method to use this custom context for `wp_kses`. [[1]](diffhunk://#diff-e3a6790de2ebcce71d98722ebc36dce43c711d945a0e79a44e9f278f5d0f19e9R28) [[2]](diffhunk://#diff-e3a6790de2ebcce71d98722ebc36dce43c711d945a0e79a44e9f278f5d0f19e9L141-R163) [[3]](diffhunk://#diff-e3a6790de2ebcce71d98722ebc36dce43c711d945a0e79a44e9f278f5d0f19e9L151-L155)